### PR TITLE
Added separatorColor support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ RNPopoverMenu.Show(this.ref, {
 | `textColor`     | `string` |         | Specify text color                                                      |
 | `borderColor`     | `string` |         | Specify border color                                                      |
 | `borderWidth`     | `number` |         | Specify border width                                                      |
-
+| `separatorColor`  | `string` |         | Specify the menu separator col                                            |
 
 
 ## Icons

--- a/ios/RNPopoverMenu.m
+++ b/ios/RNPopoverMenu.m
@@ -26,6 +26,7 @@ RCT_EXPORT_METHOD(Show:(nonnull NSNumber *)view props:(nonnull NSDictionary *)pr
     NSNumber *iconMargin = [props objectForKey: @"iconMargin"];
     NSString *selectedRowBackgroundColor = [props objectForKey: @"selectedRowBackgroundColor"];
     NSNumber *roundedArrow = [props objectForKey: @"roundedArrow"];
+    NSString *separatorColor = [props objectForKey: @"separatorColor"];
     
     NSNumber *menuWidth = [props objectForKey: @"menuWidth"];
     NSNumber *rowHeight = [props objectForKey: @"rowHeight"];
@@ -75,6 +76,13 @@ RCT_EXPORT_METHOD(Show:(nonnull NSNumber *)view props:(nonnull NSDictionary *)pr
     } else {
         borderColr = [UIColor clearColor];
     }
+
+    UIColor *separatorColr;
+    if ([separatorColor length] > 0) {
+        separatorColr = [RNPopoverMenu colorFromHexCode: separatorColor];
+    } else {
+        separatorColr = [UIColor grayColor];
+    }
     
 
     FTPopOverMenuConfiguration *configuration = [FTPopOverMenuConfiguration defaultConfiguration];
@@ -89,6 +97,7 @@ RCT_EXPORT_METHOD(Show:(nonnull NSNumber *)view props:(nonnull NSDictionary *)pr
     configuration.tintColor = tintColr;
     configuration.borderColor = borderColr;
     configuration.borderWidth = [borderWidth longValue];
+    configuration.separatorColor = separatorColr;
 //    configuration.textAlignment = ...
 //    configuration.ignoreImageOriginalColor = ...;// set 'ignoreImageOriginalColor' to YES, images color will be same as textColor
 //    configuration.allowRoundedArrow = ...// Default is 'NO', if sets to 'YES', the arrow will be drawn with round corner.

--- a/js/RNPopoverMenu.js
+++ b/js/RNPopoverMenu.js
@@ -17,6 +17,7 @@ class Popover extends PureComponent {
     textColor: PropTypes.string,
     borderWidth: PropTypes.number,
     borderColor: PropTypes.string,
+    separatorColor: PropTypes.string,
     menuWidth: PropTypes.number,
     rowHeight: PropTypes.number,
     textMargin: PropTypes.number,
@@ -36,6 +37,7 @@ class Popover extends PureComponent {
     tintColor: "",
     textColor: "",
     borderColor: "",
+    separatorColor: "",
     borderWidth: 1,
     selectedRowBackgroundColor: '',
     roundedArrow: true,
@@ -65,7 +67,8 @@ class Popover extends PureComponent {
     if (props.menus === undefined) props.menus = Popover.defaultProps.menus;
     if (props.theme === undefined) props.theme = Popover.defaultProps.theme;
     if (props.borderWidth === undefined) props.borderWidth = Popover.defaultProps.borderWidth;
-    if (props.borderColor === undefined) props.borderColor = Popover.defaultProps.borderColor;
+    if (props.borderColor === undefined) props.borderColor = Popover.defaultProps.borderColor
+    if (props.separatorColor === undefined) props.separatorColor = Popover.defaultProps.separatorColor;
 
     props.menus &&
       props.menus.forEach(menu => {


### PR DESCRIPTION
I submitted the PR https://github.com/liufengting/FTPopOverMenu/pull/24 for FTPopOverMenu that enables support of the separatorColor attribute which customizes the separator color.

This PR updates to enable support from React Native.

![image](https://user-images.githubusercontent.com/329973/41444155-0eb28708-6ff6-11e8-860f-d41d388f8e6b.png)
