### PR TITLE
Added missing props

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ RNPopoverMenu.Show(this.ref, {
 | `separatorColor`  | `string` |         | Specify the menu separator color                                          |
 | `shadowColor`  | `string` |         | Specify the shadow color |
 | `shadowOpacity`     | `float` |         | Specify shadow opacity between 0 and 1. 0 disables the shadow. |
-| `shadowColor`     | `number` |         | Specify border width                                                      |
 | `shadowRadius`     | `number` |         | Specify shadow radius                                                  |
 | `shadowOffsetX`     | `number` |         | Specify the horizontal shadow offset |
 | `shadowOffsetY`     | `number` |         | Specify the vertical shadow offset |

--- a/ios/RNPopoverMenu.m
+++ b/ios/RNPopoverMenu.m
@@ -90,7 +90,7 @@ RCT_EXPORT_METHOD(Show:(nonnull NSNumber *)view props:(nonnull NSDictionary *)pr
     }
 
     UIColor *shadowColr;
-    if ([separatorColor length] > 0) {
+    if ([shadowColor length] > 0) {
         shadowColr = [RNPopoverMenu colorFromHexCode: shadowColor];
     } else {
         shadowColr = [UIColor blackColor];

--- a/js/RNPopoverMenu.js
+++ b/js/RNPopoverMenu.js
@@ -161,6 +161,12 @@ class Popover extends PureComponent {
         selectedRowBackgroundColor: this.props.selectedRowBackgroundColor,
         menus: menus,
         theme: this.props.theme,
+        separatorColor: this.props.separatorColor,
+        shadowColor: this.props.shadowColor,
+        shadowOpacity: this.props.shadowOpacity,
+        shadowRadius: this.props.shadowRadius,
+        shadowOffsetX: this.props.shadowOffsetX,
+        shadowOffsetY: this.props.shadowOffsetY,
         onDone: this.props.onDone,
         onCancel: this.props.onCancel
       });


### PR DESCRIPTION
I added `separatorColor` and all the shadow props to the call of the native module. In the iOS module I fixed checking for a wrong variable. And I removed a wrong line from the Readme.

It probably fixes #38 