### PR TITLE
Updated version of FTPopOverMenu in podspec

### DIFF
--- a/ios/RNPopoverMenu.podspec
+++ b/ios/RNPopoverMenu.podspec
@@ -19,6 +19,6 @@ This library is a React Native bridge around native popover libraries. It allows
   s.requires_arc = true
 
   s.dependency 'React'
-  s.dependency 'FTPopOverMenu', '~> 2.0.9'
+  s.dependency 'FTPopOverMenu', '~> 2.1.1'
   s.dependency 'RNImageHelper'
 end


### PR DESCRIPTION
Updated version of dependency because of weak reference in the previous version which is not allowed for io 11+.